### PR TITLE
brew install fix (Darwin)

### DIFF
--- a/tasks/brew.yml
+++ b/tasks/brew.yml
@@ -1,8 +1,7 @@
 ---
-- name: install casks
+- name: install brew package
   become: '{{ kubernetes_helm_privilege_escalate | default(False) }}'
   become_user: root
-  with_items: '{{ kubernetes_helm_casks | default(["helm"]) }}'
-  homebrew_cask:
-    name: '{{ item }}'
+  homebrew:
+    name: '{{ kubernetes_helm_brew_pakage }}'
     state: present

--- a/tasks/brew.yml
+++ b/tasks/brew.yml
@@ -3,5 +3,5 @@
   become: '{{ kubernetes_helm_privilege_escalate | default(False) }}'
   become_user: root
   homebrew:
-    name: '{{ kubernetes_helm_brew_pakage }}'
+    name: '{{ kubernetes_helm_brew_package }}'
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
         - '{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml'
         - '{{ ansible_distribution }}.yml'
         - '{{ ansible_os_family }}.yml'
-      skip: true
+      errors: "ignore"
       paths:
         - '{{ role_path }}/vars'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
         - '{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml'
         - '{{ ansible_distribution }}.yml'
         - '{{ ansible_os_family }}.yml'
-      errors: "ignore"
+      skip: true
       paths:
         - '{{ role_path }}/vars'
 

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,4 +1,4 @@
 ---
 kubernetes_helm_privilege_escalate: False
 kubernetes_helm_installer: brew
-kubernetes_helm_brew_pakage: kubernetes-helm
+kubernetes_helm_brew_package: kubernetes-helm

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,3 +1,4 @@
 ---
 kubernetes_helm_privilege_escalate: False
 kubernetes_helm_installer: brew
+kubernetes_helm_brew_pakage: kubernetes-helm


### PR DESCRIPTION
Helm install on MacOS (Darwin), is not done by brew cask.
- Changed to install with only `brew`
- Fixed package name. Correct is `kubernetes-helm`